### PR TITLE
Use SCRIPT_DEBUG instead of WP_DEBUG

### DIFF
--- a/inc/frontend/namespace.php
+++ b/inc/frontend/namespace.php
@@ -20,7 +20,7 @@ function bootstrap() {
  */
 function output_script() {
 	// Inline for performance
-	if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+	if ( SCRIPT_DEBUG ) {
 		$files = array(
 			Gaussholder\PLUGIN_DIR . '/assets/stackblur.js',
 			Gaussholder\PLUGIN_DIR . '/assets/gaussholder.js',


### PR DESCRIPTION
As both constants are always defined via `wp_initial_constants()`, no `defined()` check is necessary

Fixes #24.