### PR TITLE
Generate placeholders in a background task

### DIFF
--- a/gaussholder.php
+++ b/gaussholder.php
@@ -22,13 +22,13 @@ require_once __DIR__ . '/inc/frontend/namespace.php';
 require_once __DIR__ . '/inc/jpeg/namespace.php';
 
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
-	require_once __DIR__  . '/inc/class-wp-cli-command.php';
+	require_once __DIR__ . '/inc/class-wp-cli-command.php';
 	WP_CLI::add_command( 'gaussholder', 'Gaussholder\\CLI_Command' );
 }
 
 add_action( 'plugins_loaded', __NAMESPACE__ . '\\Frontend\\bootstrap' );
-add_filter( 'wp_generate_attachment_metadata', __NAMESPACE__ .  '\\generate_placeholders_on_save', 10, 2 );
-
+add_filter( 'wp_update_attachment_metadata', __NAMESPACE__ . '\\queue_generate_placeholders_on_save', 10, 2 );
+add_action( 'gaussholder.generate_placeholders', __NAMESPACE__ . '\\generate_placeholders' );
 // We <3 you!
 if ( WP_DEBUG && ! defined( 'WP_I_AM_A_GRUMPY_PANTS' ) ) {
 	add_action( 'admin_head-plugins.php', function () {


### PR DESCRIPTION
Insteading of generating the placeholders in the same thread, pass them to a background task so they can be processed async. This is better for the performance when uploading images. I also moved to the `updated` rather than `generate` hook, as really I think symnatically it makes a lot more sense.

I didn't go this out of the blue, as it happens, generating placeholders on the update/generate step can be problematic. This is because the attachment metadata is not actually updated in the DB yet, so things that hook into `get_attachment_image_src` won't have the attachment sizes properly available. This was an issue when integrating Tachyon with Gaussholder.