### PR TITLE
Support url schemes in file paths

### DIFF
--- a/inc/jpeg/namespace.php
+++ b/inc/jpeg/namespace.php
@@ -187,7 +187,13 @@ function build_header() {
  * @return array 3-tuple of binary image data (string), width (int), and height (int).
  */
 function data_for_file( $file, $radius ) {
-	$editor = new Imagick( $file );
+	if ( parse_url( $file, PHP_URL_SCHEME ) ) {
+		$editor = new Imagick();
+		$editor->readImageBlob( file_get_contents( $file ) );
+	} else {
+		$editor = new Imagick( $file );
+	}
+
 	$size = $editor->getImageGeometry();
 
 	// Normalise the density to 72dpi


### PR DESCRIPTION
IMagick does _not_ like stream wrappers _at all_. In those cases, we need to init the image from a blob of the stream. This happens if you are using s3-uploads for example.