### PR TITLE
Fix images added with Gutenberg

### DIFF
--- a/inc/frontend/namespace.php
+++ b/inc/frontend/namespace.php
@@ -90,7 +90,7 @@ function mangle_images( $content ) {
 					}
 				}
 				// If we still were not able to find the image size from the src
-				// attribute, then skit this image.
+				// attribute, then skip this image.
 				if ( ! isset( $size ) ) {
 					continue;
 				}


### PR DESCRIPTION
Images inserted with Gutenberg have no size class, so we have to resort to other methods to find an image url's size. We have to look this up from all possible image sizes.