### PR TITLE
Fix stray characters in img tag attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,3 @@
 # Changelog
+
+- Bug: Fix stray characters in img tag attributes #47

--- a/inc/frontend/namespace.php
+++ b/inc/frontend/namespace.php
@@ -97,6 +97,7 @@ function mangle_images( $content ) {
 			} else {
 				$size = $size_match[1];
 			}
+
 		} else {
 			// Gallery, using `data-gaussholder-id="<id>"`
 			$id = $image[3];
@@ -150,8 +151,8 @@ function mangle_images( $content ) {
 				' src="',
 				),
 			array(
-				'data-originalsrcset="',
-				' ' . implode( ' ', $new_attrs ) . ') data-originalsrc="',
+				' data-originalsrcset="',
+				' ' . implode( ' ', $new_attrs ) . ' data-originalsrc="',
 				),
 			$tag
 		);


### PR DESCRIPTION
Ensures spaces aren't removed, and removes a stray ")" character showing up in the attributes string of the Gaussholder-enhanced image tag, when initially processing the content for image tag replacement.

Very minor bugs, don't think they'd cause any issues, but I noticed this while investigating an unrelated issue with the markup being output and wanted to PR this while I had the repo open.