### PR TITLE
Update apt-cache before installing rsync package

### DIFF
--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -57,6 +57,7 @@ git rm -rfq .
 # Sync built files
 echo -e "\nSyncing files..."
 if ! command -v 'rsync'; then
+	sudo apt-get update
 	sudo apt-get install -q -y rsync
 fi
 


### PR DESCRIPTION
The latest CircleCI builds are failing with the error message `E: Unable to locate package rsync`. This fixes that issues by running apt-get update before trying install rsync, and gets deploys working again.

Example of failed build here: https://circleci.com/gh/humanmade/Gaussholder/13