### PR TITLE
Added admin notice when Imagick is not installed

### DIFF
--- a/gaussholder.php
+++ b/gaussholder.php
@@ -19,6 +19,7 @@ define( __NAMESPACE__ . '\\PLUGIN_DIR', __DIR__ );
 
 require_once __DIR__ . '/inc/class-plugin.php';
 require_once __DIR__ . '/inc/frontend/namespace.php';
+require_once __DIR__ . '/inc/admin/namespace.php';
 require_once __DIR__ . '/inc/jpeg/namespace.php';
 
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
@@ -27,8 +28,10 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 }
 
 add_action( 'plugins_loaded', __NAMESPACE__ . '\\Frontend\\bootstrap' );
+add_action( 'admin_init', __NAMESPACE__ . '\\Admin\\bootstrap' );
 add_filter( 'wp_update_attachment_metadata', __NAMESPACE__ . '\\queue_generate_placeholders_on_save', 10, 2 );
 add_action( 'gaussholder.generate_placeholders', __NAMESPACE__ . '\\generate_placeholders' );
+
 // We <3 you!
 if ( WP_DEBUG && ! defined( 'WP_I_AM_A_GRUMPY_PANTS' ) ) {
 	add_action( 'admin_head-plugins.php', function () {

--- a/inc/admin/namespace.php
+++ b/inc/admin/namespace.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Gaussholder\Admin;
+
+/**
+ * Set up hooked callbacks on admin_init
+ */
+function bootstrap() {
+	if ( ! current_user_can( 'manage_options' ) ) {
+		return;
+	}
+
+	add_action( 'admin_notices', __NAMESPACE__ . '\\maybe_display_imagick_notice' );
+}
+
+/**
+ * Display a notice when Imagick PHP extension is not available.
+ */
+function maybe_display_imagick_notice() {
+	if ( ! class_exists( 'Imagick' ) ) {
+		?>
+		<div class="notice notice-error">
+			<p><?php _e( 'The Imagick PHP extension is not installed. Gaussholder cannot process images without it. Please, install and activate Imagick extension.', 'gaussholder' ); ?></p>
+		</div>
+		<?php
+	}
+}


### PR DESCRIPTION
Imagick is needed to use this plugin, however it is not always installed.

I've added an admin notice to display an error message when the module is not available. There are certain things that could be also improved and discussed regarding this:

- Should JPEG\data_for_file() return an error when the module is not available?
- WP CLI just displays an standard `The site is experiencing technical difficulties` error when Imagick is not installed. It took me a while to realize what was the problem. Should we also add an error message for WP CLI?
- Should the notice be dismissable?