### PR TITLE
Add Imagick exception handler

### DIFF
--- a/inc/class-plugin.php
+++ b/inc/class-plugin.php
@@ -152,7 +152,13 @@ function generate_placeholders( $attachment_id ) {
 
 	$sizes = get_enabled_sizes();
 	foreach ( $sizes as $size => $radius ) {
-		$data = generate_placeholder( $attachment_id, $size, $radius );
+		try {
+			$data = generate_placeholder( $attachment_id, $size, $radius );
+		} catch ( \ImagickException $e ) {
+			$errors->add( $size, sprintf( 'Unable to generate placeholder for %s (Imagick exception - %s)', $size, $e->getMessage() ) );
+			continue;
+		}
+
 		if ( empty( $data ) ) {
 			$errors->add( $size, sprintf( 'Unable to generate placeholder for %s', $size ) );
 			continue;


### PR DESCRIPTION
`generate_placehodlers` ( https://github.com/humanmade/Gaussholder/blob/master/inc/jpeg/namespace.php#L214) can fail. I've seen files that come with width and height = 0 for some obscure reason. However, that error is not covered by the CLI command. This PR introduces a `try/catch` block to handle that error and displays a slightly different error with some Imagick context in it so the developer will be able to find out where the error is coming from easily.